### PR TITLE
Focus on authenticator code input field on page load

### DIFF
--- a/google-authenticator.php
+++ b/google-authenticator.php
@@ -545,6 +545,11 @@ function loginform() {
     echo "\t\t<label title=\"".__('If you don\'t have Google Authenticator enabled for your WordPress account, leave this field empty.','google-authenticator')."\">".__('Google Authenticator code','google-authenticator')."<span id=\"google-auth-info\"></span><br />\n";
     echo "\t\t<input type=\"text\" name=\"googleotp\" id=\"googleotp\" class=\"input\" value=\"\" size=\"20\" style=\"ime-mode: inactive;\" autocomplete=\"off\" /></label>\n";
     echo "\t</p>\n";
+
+    // Focus the input field on page load
+    echo "\t<script type=\"text/javascript\">\n";
+    echo "\t\tfunction myFunction() { document.getElementById(\"googleotp\").focus(); }\n";
+    echo "\t</script>\n";
 }
 
 /**


### PR DESCRIPTION
It would be user friendly to directly focus on the authenticator code input field on page load. Usually you enter your login details, hit 'login', grab your phone to get the authenticator code. I find myself just typing the code, but forget to first select the input field because I am focussed on the code on my phone. 

So every time I need to first manually select the field.

By focussing on the field on page load this eliminates the manual click action.