### PR TITLE
Adds check for when roles are empty

### DIFF
--- a/google-authenticator.php
+++ b/google-authenticator.php
@@ -217,6 +217,9 @@ function user_needs_to_setup_google_authenticator() {
 	}
 
 	$must_signup = false;
+	if ( ! count( $user->roles ) ) {
+		return false;
+	}
 	$user_role = $user->roles[0];
 	$check_single_site_admin_options = true;
 


### PR DESCRIPTION
Sometimes users don't have roles, which causes a notice error when accessing them. This PR fixes it so that's checked and exits if it's the case.