### PR TITLE
Change type attribute of `<input>`

### DIFF
--- a/google-authenticator.php
+++ b/google-authenticator.php
@@ -544,7 +544,7 @@ function network_admin_setup_page() {
 function loginform() {
     echo "\t<p>\n";
     echo "\t\t<label title=\"".__('If you don\'t have Google Authenticator enabled for your WordPress account, leave this field empty.','google-authenticator')."\">".__('Google Authenticator code','google-authenticator')."<span id=\"google-auth-info\"></span><br />\n";
-    echo "\t\t<input type=\"text\" name=\"googleotp\" id=\"googleotp\" class=\"input\" value=\"\" size=\"20\" style=\"ime-mode: inactive;\" autocomplete=\"off\" /></label>\n";
+    echo "\t\t<input type=\"tel\" name=\"googleotp\" id=\"googleotp\" class=\"input\" value=\"\" size=\"20\" style=\"ime-mode: inactive;\" autocomplete=\"off\" /></label>\n";
     echo "\t</p>\n";
     echo "\t<script type=\"text/javascript\">\n";
     echo "\t\tdocument.getElementById(\"googleotp\").focus();\n";


### PR DESCRIPTION
The type attribute of the `input` tag in the form for entering the two-step verification code has been changed as follows.(Other attributes omitted)

`<input type="text">` --> `<input type='tel">`

MDN Docs https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/tel

By setting the type attribute to **tel**, the input keyboard on smartphones will default to numbers, making authentication easier.
![Screenshot_20211222_142316](https://user-images.githubusercontent.com/59349039/147040004-0a557bde-ef5d-411e-b681-a442a1f04931.jpg)

Please merging!